### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - k82cn

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
   - ihmccreery
   - ixdy
   - lavalamp

--- a/build/kube-dns/OWNERS
+++ b/build/kube-dns/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - ArtfulCoder
   - thockin

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - k82cn

--- a/cluster/mesos/docker/OWNERS
+++ b/cluster/mesos/docker/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - k82cn

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - k82cn

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
   - eparis
   - ihmccreery
   - ixdy

--- a/hack/jenkins/OWNERS
+++ b/hack/jenkins/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
   - fejta
   - ixdy
   - rmmh


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851