### PR TITLE
Update 'getting started' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ This project combines concepts and technologies from two already-complex project
 
 To get up and running with Kubernetes-Mesos, follow:
 
-- the [Getting started guide](./docs/getting-started-guides/mesos.md) to launch a Kubernetes-Mesos cluster,
+- the [Getting started guide](https://kubernetes.io/docs/getting-started-guides/mesos/) to launch a Kubernetes-Mesos cluster,
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/contrib/mesos/README.md?pixel)]()


### PR DESCRIPTION
The markdown pages in the `docs` folder has broken links. This updates the top-level readme page to point to a working 'getting started' guide.